### PR TITLE
bun actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+            bun-version: 1.0.11
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
patch for #90 

## Error Message

```shell
Run bun install
  bun install
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/a497b955-cae8-4769-a396-a38fd9ba7cfb.sh: line 1: bun: command not found
Error: Process completed with exit code 1[2](https://github.com/shunsock/resume/actions/runs/12607472961/job/35138895894#step:4:2)7.
```

## Reference

https://bun.sh/guides/runtime/cicd