### PR TITLE
feature: docker container and change root

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,10 @@
+services:
+  vitepress:
+    image: bunlovesnode/bun:1.0.12-node20.11
+    container_name: vitepress
+    volumes:
+      - ./src:/usr/vitepress/src
+    working_dir: /usr/vitepress/src
+    command: "tail -f /dev/null"
+    ports:
+      - "5173:5173"

--- a/src/docs/.vitepress/config.mts
+++ b/src/docs/.vitepress/config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  base: '/resume/',
+  base: '/',
   title: "Shunsuke Tsuchiya",
   head: [
   ['link', { rel: 'icon', type: 'image/jpeg', href: 'https://avatars.githubusercontent.com/u/84004458?s=96&v=4' }]

--- a/src/package.json
+++ b/src/package.json
@@ -4,8 +4,8 @@
     "vitepress": "^1.5.0"
   },
   "scripts": {
-    "docs:dev": "vitepress dev docs",
+    "docs:dev": "vitepress dev docs --host",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs --host"
   }
 }


### PR DESCRIPTION
## 概要

- ドメイン shunsock.com を取得しました。これにより、サブドメイン `resume` に流す必要がなくなったので、`vitepress`のrootを変更します。
- ローカルでの開発を楽にするためにDocker Containerの導入をしました。