### PR TITLE
fix: シェルスクリプトにshebang行を追加

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 nix run .#build

--- a/script/run.sh
+++ b/script/run.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 nix run


### PR DESCRIPTION
## Summary
- `script/run.sh` と `script/build.sh` に `#!/usr/bin/env bash` を追加
- ShellCheck SC2148 エラーを解消

## Test plan
- [ ] CI の ShellCheck ジョブが Pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)