### PR TITLE
update README.md and CLAUDE.md to reflect current directory structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,22 +34,24 @@ resume/
 │   ├── .vitepress/         # VitePress configuration
 │   │   └── config.mts      # Main site configuration
 │   ├── blog/               # Blog posts (technology, daily)
-│   ├── profile/            # Profile info, resume, skills
-│   ├── works/              # Work projects (Findy, PR TIMES, presentations)
-│   ├── image/              # Static assets
+│   ├── presentation/       # Presentations at conferences
+│   ├── project/            # Work projects (Findy, PR TIMES)
+│   ├── public/             # Static assets (images, logos)
+│   ├── resume/             # Resume and career history
+│   ├── skill/              # Skills and technologies
 │   └── index.md            # Homepage
 ├── flake.nix               # Nix development environment
 ├── flake.lock              # Nix lock file
 ├── Taskfile.yml            # Task runner configuration
 ├── package.json            # Dependencies and scripts
-└── bun.lockb              # Bun lock file
+└── bun.lock                # Bun lock file
 ```
 
 ## Content Organization
 
 - Navigation and sidebar are configured in `docs/.vitepress/config.mts`
 - All content is in Markdown format
-- Images are stored in `docs/image/` with subdirectories by category
+- Images are stored in `docs/public/` with subdirectories by category
 - Site uses local search provider (configured in VitePress config)
 
 ## Development Environment

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ bun run docs:preview     # Preview the built site
 
 3. Start the development server
    ```bash
-   task start
+   task run
    ```
 
 4. Open your browser and visit `http://localhost:5173/resume/`
@@ -77,12 +77,12 @@ If you prefer not to use Nix:
 
 3. Start the development server
    ```bash
-   task start
+   task run
    # Or run directly:
    bun run docs:dev
    ```
 
-4. Open your browser and visit `http://localhost:5173/`
+4. Open your browser and visit `http://localhost:5173/resume/`
 
 
 ## CI/CD
@@ -116,7 +116,7 @@ The `.github/workflows/deploy.yml` workflow is triggered when changes are pushed
 
 - Navigation and sidebar are configured in `docs/.vitepress/config.mts`
 - All content is in Markdown format
-- Images are stored in `docs/image/` with subdirectories by category
+- Images are stored in `docs/public/` with subdirectories by category
 - Site uses local search provider (configured in VitePress config)
 
 ## Project Structure
@@ -128,16 +128,18 @@ resume/
 │   ├── .vitepress/         # VitePress configuration
 │   │   └── config.mts      # Main site configuration
 │   ├── blog/               # Blog posts (technology, daily)
-│   ├── profile/            # Profile info, resume, skills
-│   ├── works/              # Work projects (Findy, PR TIMES, presentations)
-│   ├── image/              # Static assets
+│   ├── presentation/       # Presentations at conferences
+│   ├── project/            # Work projects (Findy, PR TIMES)
+│   ├── public/             # Static assets (images, logos)
+│   ├── resume/             # Resume and career history
+│   ├── skill/              # Skills and technologies
 │   └── index.md            # Homepage
 ├── script/                 # Development scripts
 ├── flake.nix               # Nix development environment
 ├── flake.lock              # Nix lock file
 ├── Taskfile.yml            # Task runner configuration
 ├── package.json            # Dependencies and scripts
-├── bun.lockb               # Bun lock file
+├── bun.lock                # Bun lock file
 └── README.md               # This file
 ```
 


### PR DESCRIPTION
## Summary
- `docs/` 配下のディレクトリ構造を実態に合わせて更新（`profile/` → `resume/`, `works/` → `project/`, `image/` → `public/`, `skill/`, `presentation/` を追加）
- Taskfile のコマンド名を修正（`task start` → `task run`）
- ロックファイル名を修正（`bun.lockb` → `bun.lock`）
- 開発サーバーURLを修正（`http://localhost:5173/` → `http://localhost:5173/resume/`）

## Test plan
- [ ] `bun run docs:build` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)