### PR TITLE
docs: Zenn・noteブログ記事一覧を更新

### DIFF
--- a/docs/blog/note/index.md
+++ b/docs/blog/note/index.md
@@ -13,6 +13,10 @@ next:
 
 noteに投稿した記事の一覧です。日常の内容が多めです。
 
+- [フロントエンド・PHPカンファレンスで登壇しました](https://note.com/shunsock/n/n53c5f628f745)
+- [俺の考えた最強の作業環境](https://note.com/shunsock/n/nb667aecbd359)
+- [株式会社ナウキャストに入社します](https://note.com/shunsock/n/n5a3e2a6d4ecd)
+- [事業所を家にして生活している話](https://note.com/shunsock/n/nac31b8a714c8)
 - [堅牢.py #2 を開催しました](https://note.com/shunsock/n/nc84faf7561e1)
 - [Python製ソフトウェアを堅牢にする技術に特化したイベント「堅牢.py #2」を2026年3月6日に開催致します](https://note.com/shunsock/n/n8f94a420052f)
 - [2025年の振り返り](https://note.com/shunsock/n/n3d9ec9367121)
@@ -21,7 +25,7 @@ noteに投稿した記事の一覧です。日常の内容が多めです。
 - [YAPC::Fukuoka 2025に参加しました](https://note.com/shunsock/n/n39a4144f9aef)
 - [Python製ソフトウェアを堅牢にする技術に特化したイベント「堅牢.py」を2025年11月20日に開催致します](https://note.com/shunsock/n/n35350d54dd0c)
 - [uvに貢献した話](https://note.com/shunsock/n/nf5c615f351bc)
-- [https://note.com/shunsock/n/n8896a166774c](https://note.com/shunsock/n/n8896a166774c)
+- [Mac miniを導入した話](https://note.com/shunsock/n/n8896a166774c)
 - [PyCon JP 2025に参加しました](https://note.com/shunsock/n/n0e2541ac3fdc)
 - [ArcファンはFirefoxを触ってほしい](https://note.com/shunsock/n/n187054495409)
 - [ファインディに入社して1年が経ちました](https://note.com/shunsock/n/n530f24bf8ead)

--- a/docs/blog/zenn/index.md
+++ b/docs/blog/zenn/index.md
@@ -4,15 +4,14 @@ description: 個人のテックブログ
 prev:
   text: "PR TIMES開発者ブログ"
   link: "/blog/prtimes_techblog"
-next:
-  text: "Tech Blog"
-  link: "/blog/technology"
 ---
 
 # Zenn
 
 2022年から個人のテックブログを掲載しています。
 
+- [FastAPI Cloudを使ってみた](https://zenn.dev/shundeveloper/articles/93417d82f02dd5)
+- [TerraformリポジトリをAI利用前提の構成にリアーキテクトした話](https://zenn.dev/shundeveloper/articles/aac64078ec57f2)
 - [LazyNixとuvでお手軽Python開発](https://zenn.dev/shundeveloper/articles/c74a9afbf1e786)
 - [LazyNix: 誰でも作れる再現可能な開発環境](https://zenn.dev/shundeveloper/articles/6d9a464c4a6bad)
 - [開発環境現状確認（2026年）](https://zenn.dev/shundeveloper/articles/e403a5083148d2)


### PR DESCRIPTION
## 概要

外部プラットフォーム (Zenn / note) に公開済みで本サイトの一覧に未掲載だった計6記事を追加し、あわせてリンクの不備2件を修正する。

## 背景

`docs/blog/` 配下の記事一覧は外部記事への手動リンク集であり、記事公開のたびに追随が必要になる。前回更新 (2026年2月頃) 以降に公開された記事が未掲載のままになっていた。

## 課題

- Zenn の直近2記事、note の直近4記事が一覧から漏れており、サイト訪問者が最新の執筆活動を把握できない
- note 一覧に生 URL がそのままリンクテキストになっている行があった
- Zenn ページの frontmatter `next` が存在しない `/blog/technology` を指していた

## 目標

### 必須項目

- RSS フィードと一覧の差分をすべて解消する (Zenn 2件 / note 4件)
- リンク不備 (生URL・stale link) を修正する

### 範囲外

- 一覧の並び順の再編 (Zenn の既存部分はかな順のまま維持)
- ブログ一覧生成の自動化

## 採用手法

各プラットフォームの RSS フィード (`zenn.dev/shundeveloper/feed` / `note.com/shunsock/rss`) と既存一覧を突合し、差分のみを既存フォーマット (新しい順に先頭へ追加) で挿入した。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 差分のみ手動追記 (採用) | 既存の並び・体裁を壊さない最小変更 | 次回以降も手動追随が必要 |
| B: RSS からの一覧自動生成 | 追随漏れがなくなる | ビルドパイプラインの変更が必要でこの PR の範囲を超える |

### 採用理由

本 PR はメンテナンス作業の一環であり、コンテンツの鮮度回復が目的。自動化はリポジトリ構造の変更を伴うため別途検討とする。

## 変更箇所

- `docs/blog/zenn/index.md`: 記事2件を先頭に追加、存在しない `/blog/technology` への `next` リンクを削除 (サイドバー上 Zenn は最終項目のため `next` 自体が不要)
- `docs/blog/note/index.md`: 記事4件を先頭に追加、生URLだったリンクテキストを「Mac miniを導入した話」に修正

## 妥協と制限

- **手動追随の継続**: 一覧は引き続き手動更新。自動化は将来課題

## 検証方法

- `nix develop -c bun run docs:build` でビルド成功を確認 (VitePress は dead link をビルドエラーにするため、リンク健全性も同時に検証される)
- 追加した6記事の URL は RSS フィード取得値をそのまま使用

## 確認事項

- ⚠️ note の告知系記事 (開催告知など) も従来どおり一覧に含める方針を踏襲した。除外したい記事があれば指摘してほしい

## 参考文献

- [Zenn RSS](https://zenn.dev/shundeveloper/feed)
- [note RSS](https://note.com/shunsock/rss)