### PR TITLE
docs: 職務経歴と登壇情報を更新

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ features:
 
 国内の主要カンファレンスに多数登壇しております。
 
+- フロントエンド・PHPカンファレンス北海道 2026
 - DB TECH SHOWCASE 2025
 - PHP Conference Japan 2024/2025
 - PHPerKaigi 2024/2025

--- a/docs/presentation/index.md
+++ b/docs/presentation/index.md
@@ -7,6 +7,23 @@ description: カンファレンスでの登壇と講演の情報
 
 登壇・講演の情報
 
+## フロントエンド・PHPカンファレンス北海道 2026
+
+### 概要
+
+- タイトル: ユーザーに「👍」と「👎」の押しミスをさせない設計にしよう
+- 日付: 2026-06-06
+- イベント名称: [フロントエンド・PHPカンファレンス北海道 2026](https://frontend-php-con.hokkaido.jp/)
+- 場所: Sapporo, Japan
+- 資料:
+    - Speaker Deck: [「👍」と「👎」の押しミスに震えない世界を作りませんか?](https://speakerdeck.com/shunsock/to-noya-simisunizhen-enaishi-jie-wozuo-rimasenka)
+    - Zenn: [ユーザーに「👍」と「👎」の押しミスをさせない設計にしよう](https://zenn.dev/shundeveloper/articles/6d489ed4398b0b)
+    - note: [フロントエンド・PHPカンファレンスで登壇しました](https://note.com/shunsock/n/n53c5f628f745)
+
+### 内容
+
+「👍」と「👎」のような絵文字リアクションボタンが Unicode の文字コード順で隣接して並ぶことによる押しミスの問題を取り上げた LT です。文字コード順ではなく感情の意味順 (ポジティブ → ニュートラル → ネガティブ) に並べることで、ユーザーが意図と逆のリアクションを誤送信してしまう事故を設計で防げることを、Google Meet などの実例を交えて紹介しました。
+
 ## DB TECH SHOWCASE 2025
 
 ### 概要

--- a/docs/resume/index.md
+++ b/docs/resume/index.md
@@ -35,6 +35,9 @@ next:
 
 - 会社名: [株式会社ナウキャスト](https://nowcast.co.jp/)
 - 所属期間: 2026-04-01 - 現在
+- 職種: プロダクトエンジニア
+- 業務内容:
+    - 店舗開発DXツール「[DataLens店舗開発](https://lp.datalenshub.com/property)」の開発
 
 ### ファインディ株式会社
 
@@ -55,7 +58,7 @@ next:
 - 会社名: 株式会社インフラトップ
 - 創業: 2014年11月19日
 - 従業員数: 非公表
-- 所属期間: 2025-06-01 - 現在
+- 所属期間: 2025-06-01 - 2026-01-31
 - 所属部署: 学習支援チーム
 - 職種: プログラミング講師
 - 業務内容:
@@ -66,7 +69,7 @@ next:
 - 会社名: A1A株式会社
 - 創業: 2018年6月26日
 - 従業員数: 非公表
-- 所属期間: 2024-09-01 - 現在
+- 所属期間: 2024-09-01 - 2025-06-30
 - 所属部署: プロダクトチーム
 - 職種: 技術調査、設計レビュー、開発等
 - 業務内容:
@@ -94,13 +97,14 @@ next:
 
 ## Presentation / 登壇
 
+- [フロントエンド・PHPカンファレンス北海道 2026](https://frontend-php-con.hokkaido.jp/): LT登壇
 - [DB TECH SHOWCASE 2025](https://www.db-tech-showcase.com/2025): トーク登壇
 - [PHPerKaigi 2025](https://phperkaigi.jp/2025/): トーク登壇
 - [PHPerKaigi 2024](https://phperkaigi.jp/2024/): トーク登壇
-- [PHP Conference Japan 2024](https://phpcon.php.gr.jp/2025/): LT登壇
-- [PHP Conference Japan 2025](https://phpcon.php.gr.jp/2024/): トーク登壇
+- [PHP Conference Japan 2024](https://phpcon.php.gr.jp/2024/): LT登壇
+- [PHP Conference Japan 2025](https://phpcon.php.gr.jp/2025/): トーク登壇
 - [PyCon Kyushu 2024](https://kyushu.pycon.jp/2024/): トーク登壇
-- [YAPC::Kyoto 2023](https://yapcjapan.org/2023kyoto/): LT登壇 (ベストLT章受賞)
+- [YAPC::Kyoto 2023](https://yapcjapan.org/2023kyoto/): LT登壇 (ベストLT賞受賞)
 
 ## Awards / 受賞歴
 


### PR DESCRIPTION
## 概要

職務経歴書のナウキャスト職務内容の追記・兼務終了の反映と、フロントエンド・PHPカンファレンス北海道 2026 の登壇情報追加を行う。

## 背景

2026年4月のナウキャスト入社時にプロフィールは更新済みだったが、職種・業務内容は未記載のままだった。また兼務先 (A1A・インフラトップ) の終了が反映されておらず、2026年6月の登壇も presentation ページに未掲載だった。

## 課題

- ナウキャストのエントリが所属期間とリンクのみで、他社エントリと比べ情報量が乏しい
- A1A・インフラトップの所属期間が「現在」のままで実態と乖離
- フロントエンド・PHPカンファレンス北海道 2026 での LT 登壇が presentation ページ・職務経歴書・トップページのいずれにも未掲載
- 職務経歴書の登壇リストで PHP Conference Japan 2024/2025 のリンク先 URL が入れ替わっていた

## 目標

### 必須項目

- ナウキャストの職種・業務内容を追記する
- 兼務2社の終了日を反映する
- 2026-06-06 の登壇を3ページに反映する

### 範囲外

- 過去登壇の Canva 資料の Speaker Deck への移行 (Speaker Deck 未アップロードのため、アップロード後に差し替え予定)

## 採用手法

公開情報 (Speaker Deck・note 記事・イベント公式サイト・ナウキャストのニュースリリース) を突合し、既存フォーマットを踏襲して追記した。

## 変更箇所

- `docs/resume/index.md`: ナウキャストに職種「プロダクトエンジニア」と業務内容「[DataLens店舗開発](https://lp.datalenshub.com/property)の開発」を追記 / A1A 終了 2025-06-30・インフラトップ終了 2026-01-31 / 登壇リスト追加・URL 入れ替え修正・「ベストLT章」誤字修正
- `docs/presentation/index.md`: フロントエンド・PHPカンファレンス北海道 2026 のエントリを先頭に追加 (Speaker Deck / Zenn / note の資料リンク付き)
- `docs/index.md`: 発表・登壇リストに同カンファレンスを追加

## 妥協と制限

- **兼務終了日は月末日付の概算**: 本人申告が「2025年6月頃」「2026年1月頃」のため、A1A は 2025-06-30、インフラトップは 2026-01-31 とした

## 検証方法

- `nix develop -c bun run docs:build` でビルド成功 (dead link 検査込み) を確認
- DataLens店舗開発のサービスサイト URL は [ナウキャストのニュースリリース](https://nowcast.co.jp/news/20250804-2/) から取得
- イベント名・日付・会場は [公式サイト](https://frontend-php-con.hokkaido.jp/) と Speaker Deck の記載で確認

## 確認事項

- ⚠️ 兼務2社の終了日 (2025-06-30 / 2026-01-31) は概算。正確な日付が分かれば修正してほしい
- ⚠️ ナウキャストの「所属部署」は情報がないため未記載とした。必要なら追記してほしい

## 参考文献

- [Speaker Deck: 「👍」と「👎」の押しミスに震えない世界を作りませんか?](https://speakerdeck.com/shunsock/to-noya-simisunizhen-enaishi-jie-wozuo-rimasenka)
- [note: フロントエンド・PHPカンファレンスで登壇しました](https://note.com/shunsock/n/n53c5f628f745)
- [フロントエンド・PHPカンファレンス北海道 2026](https://frontend-php-con.hokkaido.jp/)
- [DataLens店舗開発 サービスサイト公開のお知らせ](https://nowcast.co.jp/news/20250804-2/)