### PR TITLE
build(deps): 依存関係を更新し dependabot の bun 設定を修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     reviewers:
       - "shunsock"
   - package-ecosystem: "bun"
-    directory: "/src"
+    directory: "/"
     schedule:
       interval: "monthly"
     reviewers:

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
   "workspaces": {
     "": {
       "devDependencies": {
-        "vitepress": "^1.5.0",
+        "vitepress": "^1.6.4",
       },
     },
   },
@@ -339,7 +339,7 @@
 
     "vite": ["vite@5.4.19", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA=="],
 
-    "vitepress": ["vitepress@1.6.3", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw=="],
+    "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
 
     "vue": ["vue@3.5.18", "", { "dependencies": { "@vue/compiler-dom": "3.5.18", "@vue/compiler-sfc": "3.5.18", "@vue/runtime-dom": "3.5.18", "@vue/server-renderer": "3.5.18", "@vue/shared": "3.5.18" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA=="],
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765311797,
-        "narHash": "sha256-mSD5Ob7a+T2RNjvPvOA1dkJHGVrNVl8ZOrAwBjKBDQo=",
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09eb77e94fa25202af8f3e81ddc7353d9970ac1b",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
         "type": "github"
       },
       "original": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "devDependencies": {
-    "vitepress": "^1.5.0"
+    "vitepress": "^1.6.4"
   },
   "scripts": {
     "docs:dev": "vitepress dev docs --host",


### PR DESCRIPTION
## 概要

vitepress と nixpkgs (flake.lock) を更新し、機能していなかった dependabot の bun ecosystem 設定を修正する。

## 背景

定期メンテナンスの一環。依存関係を確認したところ、flake.lock の nixpkgs が約7ヶ月前 (2025-12-09) で止まっており、dependabot の bun ecosystem が誤った directory (`/src`) を指しているため bun 依存の更新 PR が一度も作られていないことが判明した (直近の dependabot PR は github-actions のみ)。

## 課題

- `dependabot.yml` の bun ecosystem `directory: "/src"` が実際の `package.json` の位置 (リポジトリルート) と不一致で、更新スキャンが空振りしていた
- vitepress が 1.6.3 のまま (最新 1.6.4)
- nixpkgs (nixos-25.11) の lock が7ヶ月前で、devShell のツール (bun / go-task) が古いまま

## 目標

### 必須項目

- dependabot の bun スキャンを機能させる
- vitepress / nixpkgs を最新に更新し、ビルドが通ることを確認する

### 範囲外

- vitepress 2.x 系への major アップグレード (安定版が ^1 系の範囲外のため別途検討)
- flake input の追加・変更 (nixos-25.11 ブランチは維持)

## 採用手法

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 通常の update コマンドで lock を更新 (採用) | `bun update` / `nix flake update` の標準フローで再現可能 | - |
| B: dependabot 修正のみ入れて更新は dependabot に任せる | 手作業が減る | 月次スケジュール + cooldown のため反映が遅い。7ヶ月分の遅れを今解消できない |

directory 修正と実更新を同時に入れることで、以後の追随は dependabot に引き継げる。

## 変更箇所

- `.github/dependabot.yml`: bun ecosystem の `directory: "/src"` → `"/"`
- `package.json` / `bun.lock`: vitepress 1.6.3 → 1.6.4 (spec は ^1.6.4 に追随)
- `flake.lock`: nixpkgs (nixos-25.11) 2025-12-09 → 2026-06-30

## 妥協と制限

- **#158 とのわずかな競合可能性**: #158 (devtools 導入) も `dependabot.yml` に cooldown を追加している。マージ順によっては手動での rebase が必要になる場合がある

## 検証方法

- `nix develop -c bun run docs:build` で更新後のツールチェーン (新 nixpkgs の bun + vitepress 1.6.4) によるビルド成功を確認

## 確認事項

- ⚠️ dependabot の bun スキャンは本 PR マージ後の次回スケジュール (monthly) から有効になる

## 参考文献

- [vitepress 1.6.4](https://www.npmjs.com/package/vitepress)
- [Dependabot: package-ecosystem / directory](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)