### PR TITLE
ci: dependabot の patch / minor 更新を auto-merge する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,10 @@
 name: Build Test
 
+# build-test を branch protection の required status check にするため
+# paths フィルタを設けず全 PR で実行する (path 限定だと check が報告されず merge が塞がる)。
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - 'docs/**'
-      - 'bun.lock'
-      - 'package.json'
-      - 'flake.nix'
-      - 'flake.lock'
 
 # 既定では何も書き込ませない (最小権限)。checkout に必要な read のみ job 側で付与する。
 permissions: {}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/merge__dependabot.yaml
+++ b/.github/workflows/merge__dependabot.yaml
@@ -1,0 +1,37 @@
+name: merge__dependabot
+
+# dependabot が作成した PR のうち patch / minor 更新に auto-merge を設定する。
+# major 更新は影響が大きいため対象外とし、手動レビューに委ねる。
+# 実際のマージは main の required status checks (branch protection) を
+# すべて満たした時点で GitHub の auto-merge が実行する。
+
+on:
+  pull_request:
+    branches: [main]
+
+# 既定では何も書き込ませない (最小権限)。auto-merge 設定に必要な権限は job 側で付与する。
+permissions: {}
+
+jobs:
+  auto_merge:
+    # dependabot の PR のみを対象とし、人間の PR には作用させない。
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # マージ方式は既存履歴に合わせて merge commit とする。
+      - name: Enable auto-merge for patch / minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge__dependabot.yaml
+++ b/.github/workflows/merge__dependabot.yaml
@@ -16,7 +16,7 @@ jobs:
   auto_merge:
     # dependabot の PR のみを対象とし、人間の PR には作用させない。
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: write


### PR DESCRIPTION
## 概要

dependabot PR のうち patch / minor 更新を GitHub の auto-merge で自動マージし、major 更新のみ手動レビューに残す仕組みを導入する。

## 背景

dependabot の更新 PR (monthly + cooldown 7日) はこれまで全件手動マージだった。patch / minor はリスクが低く、CI (lint 5チェック + build-test) が通れば機械的にマージして問題ないため、レビューコストを major 更新に集中させたい。

## 課題

- patch / minor の依存更新 PR のマージが人手待ちで滞留する
- `build.yml` が paths フィルタ付きのため、required status check にすると path 非該当の PR で check が報告されず merge が永久に塞がる

## 目標

### 必須項目

- dependabot の patch / minor 更新 PR に auto-merge を設定する (CI 全パス後に GitHub がマージ)
- major 更新には作用しない

### 範囲外

- branch protection の設定自体 (workflow では設定できないため、`gh api` で別途実施する)
- dependabot PR 以外の自動マージ

## 採用手法

GitHub 公式ドキュメント ([Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)) のパターンに従い、`dependabot/fetch-metadata` で update-type を判定し、`semver-major` 以外に `gh pr merge --auto --merge` を実行する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: 公式 auto-merge 方式 (採用) | required checks 全パスを GitHub 側が保証。実装が薄い | branch protection の事前設定が必要 |
| B: workflow 内で CI 完了をポーリングして直接 merge | repo 設定変更が不要 | 監視ロジックの自前実装になり、チェック追加時に追随漏れのリスク |

### 採用理由

「CI が通ったらマージ」の判定は GitHub の auto-merge が所有するのが最も宣言的で、workflow 側は「auto-merge を有効化するか」の判定だけに責務を絞れる。

## 変更箇所

- `.github/workflows/merge__dependabot.yaml`: 新規。dependabot PR の patch / minor に auto-merge を設定 (SHA pin / job 単位の最小権限 / timeout 付き)
- `.github/workflows/build.yml`: paths フィルタを削除し全 PR で build-test を実行 (required status check 化の前提。実行時間は約30秒で負荷は軽微)

## 妥協と制限

- **GITHUB_TOKEN による auto-merge は後続 workflow をトリガーしない**: bun 系の更新が自動マージされた際、main への push で `deploy.yml` が発火しない (GitHub の再帰防止仕様)。サイト内容は依存更新では変わらないため実害は小さく、次の docs 変更マージ時に再デプロイされる。即時反映が必要な場合は `workflow_dispatch` で手動デプロイできる。恒久対応するなら PAT / GitHub App token が必要
- **branch protection が前提**: 保護ルール未設定の間は `gh pr merge --auto` が失敗しうる。本 PR のマージ後に `gh api` で設定する

## 検証方法

- `nix run nixpkgs#actionlint` / `ghalint run` / `zizmor --offline` / `ls-lint`: すべて pass
- 実際の自動マージ動作は次回の dependabot PR (monthly) で確認する

## 確認事項

- ⚠️ マージ方式は既存履歴に合わせて merge commit (`--merge`) とした
- ⚠️ deploy が発火しない制限 (上記) を許容できるか。PAT 対応が必要なら別途相談

## 参考文献

- [Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
- [dependabot/fetch-metadata v3.1.0](https://github.com/dependabot/fetch-metadata/releases/tag/v3.1.0)