### PR TITLE
chore: workflow ファイル名を 動詞__対象.yaml 形式に統一

### DIFF
--- a/.github/workflows/build__site.yaml
+++ b/.github/workflows/build__site.yaml
@@ -1,4 +1,4 @@
-name: Build Test
+name: build__site
 
 # build-test を branch protection の required status check にするため
 # paths フィルタを設けず全 PR で実行する (path 限定だと check が報告されず merge が塞がる)。

--- a/.github/workflows/deploy__site.yaml
+++ b/.github/workflows/deploy__site.yaml
@@ -1,14 +1,14 @@
-name: Deploy static content to Pages
+name: deploy__site
 
 on:
   push:
     branches: ["main"]
     paths:
-      - 'docs/**'
-      - 'bun.lock'
-      - 'package.json'
-      - 'flake.nix'
-      - 'flake.lock'
+      - "docs/**"
+      - "bun.lock"
+      - "package.json"
+      - "flake.nix"
+      - "flake.lock"
 
   workflow_dispatch:
 
@@ -49,7 +49,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: './docs/.vitepress/dist'
+          path: "./docs/.vitepress/dist"
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you prefer not to use Nix:
 
 ### Build
 
-The `.github/workflows/build.yml` workflow is triggered when a pull request is opened against the main branch. This workflow only runs if changes are made within the `docs` directory or other relevant files.
+The `.github/workflows/build__site.yaml` workflow is triggered when a pull request is opened against the main branch. It runs on every pull request so that the `build-test` job can serve as a required status check.
 
 The build process is significant as it performs dead link checking to ensure all internal and external links remain functional before merging changes.
 
@@ -106,11 +106,11 @@ Review feedback is categorized as `[must]` (critical changes), `[nits]` (improve
 
 ### Shell Script Validation
 
-The `.github/workflows/validate_shellscript.yml` workflow runs ShellCheck validation on shell scripts in the `script/` directory when pull requests modify any `.sh` files. This ensures shell script quality and catches common scripting issues before merge.
+The `.github/workflows/lint__shell.yaml` workflow runs shfmt and ShellCheck validation on shell scripts in the repository. This ensures shell script quality and catches common scripting issues before merge.
 
 ### Deploy
 
-The `.github/workflows/deploy.yml` workflow is triggered when changes are pushed to the main branch. Similar to the CI workflow, deployment only proceeds if there are changes detected in the relevant directories.
+The `.github/workflows/deploy__site.yaml` workflow is triggered when changes are pushed to the main branch. Deployment only proceeds if there are changes detected in the relevant directories.
 
 ## Content Organization
 


### PR DESCRIPTION
## 概要

`.github/workflows/` 配下で `build.yml` / `deploy.yml` だけが旧命名 (平坦名 + `.yml`) のまま残っていたため、他の 4 本と同じ `動詞__対象.yaml` 形式にリネームする。ファイル種別ごとの命名規則統一シリーズの第 1 弾 (GitHub Actions ワークフロー編)。

## 背景

devtools 配布ワークフローの導入以降、`lint__directory_name.yaml` / `lint__github_actions.yaml` / `lint__shell.yaml` / `merge__dependabot.yaml` は `動詞__対象.yaml` という統一された命名を持つ。一方、リポジトリ初期から存在する `build.yml` / `deploy.yml` は旧来の平坦な命名と `.yml` 拡張子のままで、ディレクトリ内に 2 つの命名体系が混在していた。

## 課題

- 拡張子が `.yml` と `.yaml` で混在し、glob やツール設定で拾い漏れの温床になる
- ファイル名から「何をするワークフローか (動詞) / 何に対してか (対象)」が読み取れる新形式と、読み取れない旧形式が並存し、一覧性が損なわれている
- `name:` フィールドも新形式はファイル名と一致するが、旧形式は自由文 (`Build Test` など) で、Actions の UI 上の表示とファイルの対応が取りにくい

## 目標

### 必須項目

- `build.yml` → `build__site.yaml`、`deploy.yml` → `deploy__site.yaml` へのリネーム
- `name:` フィールドをファイル名と一致させる
- README のワークフロー参照を実在するファイル名に更新する
- required status check (`build-test`) を壊さない

### 範囲外

- ジョブ ID / ジョブ名の変更 (ruleset の required checks が参照しているため)
- トリガー条件・権限・ステップ内容の変更

## 採用手法

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: ファイル名と `name:` のみ変更 (採用) | ruleset の required checks (ジョブ名参照) に影響なし。挙動が変わらない | ジョブ名の命名揺れ (`build-test` kebab vs `ls_lint` snake) は残る |
| B: ジョブ名まで snake_case に統一 | 命名が完全に揃う | ruleset「master」の required_status_checks の同時更新が必要で、タイミングを誤ると全 PR のマージが塞がる |

### 採用理由

required status check はワークフロー名ではなくジョブ名 (`build-test`) を参照する。ファイル名と `name:` の変更は check の識別子に影響しないため、ruleset を触らずに安全に命名を統一できる範囲だけを対象にした。ジョブ名の統一は ruleset 更新と同時に行う必要があるため、別途切り出す。

## 変更箇所

- `.github/workflows/build.yml` → `.github/workflows/build__site.yaml`: リネームし `name:` を `build__site` に変更
- `.github/workflows/deploy.yml` → `.github/workflows/deploy__site.yaml`: リネームし `name:` を `deploy__site` に変更 (prettier によるクォート統一を含む)
- `README.md`: ワークフロー参照を新ファイル名に更新。存在しない `validate_shellscript.yml` への言及を実在する `lint__shell.yaml` に修正し、build が全 PR で走る現仕様に記述を合わせた

## 妥協と制限

- **ジョブ名の命名揺れは未解消**: `build-test` (kebab) と `ls_lint` (snake) の混在は残る。解消には ruleset の required checks 更新が必要なため、この PR では扱わない

## 検証方法

- prettier / yamllint / actionlint をローカルで実行しすべてパス (yamllint は既存慣習の SHA pin コメント warning のみ)
- 埋め込み `run:` ブロックの認知的複雑度を計測 (0.00 ≤ 6)
- ジョブ ID が変更されていないことを diff で確認 (required check `build-test` は維持)

## 確認事項

- ⚠️ `deploy__site.yaml` は `対象 = サイト` として `build__site.yaml` と対で命名した。デプロイ先を明示する `deploy__github_pages.yaml` という案もあったが、build / deploy が同一成果物を扱う対称性を優先した
- ⚠️ workflow ファイルを変更する PR のため、gh CLI トークン (workflow scope なし) では auto-merge を有効化できない。マージは Web UI から行う必要がある

## 参考文献

- [ls-lint 設定 (.ls-lint.yml)](https://github.com/shunsock/resume/blob/main/.ls-lint.yml)
- [devtools 配布ワークフロー導入 PR #158](https://github.com/shunsock/resume/pull/158)

🤖 Generated with [Claude Code](https://claude.com/claude-code)