### PR TITLE
chore: nixpkgs 26.05 へのチャンネル更新と GitHub Actions pin の更新

### DIFF
--- a/.github/workflows/build__site.yaml
+++ b/.github/workflows/build__site.yaml
@@ -17,13 +17,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # build 検証では認証情報を残す必要がない (最小権限)。
           persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
       - name: Build Site
         run: bash script/build.sh

--- a/.github/workflows/deploy__site.yaml
+++ b/.github/workflows/deploy__site.yaml
@@ -32,13 +32,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # deploy は Pages artifact 経由で行うため認証情報を残す必要がない (最小権限)。
           persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
       - name: Build Site
         run: bash script/build.sh

--- a/.github/workflows/lint__directory_name.yaml
+++ b/.github/workflows/lint__directory_name.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # lint 専用 job では認証情報を残す必要がない (最小権限)。
           persist-credentials: false

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Bun Development Shell";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
## 概要

リポジトリが利用するツールチェーンを棚卸しし、古くなっていた nixpkgs チャンネル (nixos-25.11 → nixos-26.05) と GitHub Actions の SHA pin (actions/checkout v7.0.1、cachix/install-nix-action v31.11.0) を更新する。

## 背景

本サイトのビルド環境は Nix flake (bun / go-task) と GitHub Actions の SHA pin で再現可能に固定している。固定は再現性を担保する一方、上流のリリースに追従しないと古いチャンネル・古い action に留まり続ける。今回、利用中の全ツールのバージョンを一括で検証した。

## 課題

検証の結果、次の 2 点が古くなっていた。

- nixpkgs が nixos-25.11 チャンネルを指しており、2026-05 リリースの nixos-26.05 に未追従だった
- actions/checkout (v7.0.0) と cachix/install-nix-action (v31.10.6) に新しいリリース (v7.0.1 / v31.11.0) が出ていた

一方、VitePress (1.6.4)・flake-utils・configure-pages・upload-pages-artifact・deploy-pages・ls-lint・fetch-metadata はすべて最新であることを確認した (VitePress 2.0 は alpha のため対象外)。

## 目標

### 必須項目

- nixpkgs を nixos-26.05 チャンネルへ更新し、サイトビルドが成功すること
- リポジトリが直接管理する workflow の action pin を最新リリースの commit SHA へ更新すること

### 範囲外

- `MANAGED BY shunsock/github_central` の workflow (lint__csharp / lint__github_actions / lint__shell) — 同期で上書きされるため、pin 更新 (checkout v7.0.1、zizmor-action v0.6.0、zizmor v1.27.0 等) は github_central 側で行う
- VitePress 2.0 (alpha) への移行

## 採用手法

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: チャンネル bump + 最新タグの SHA pin 更新 (採用) | 再現性を保ったまま安定版へ追従できる | 上流リリースごとに手動更新が必要 (dependabot が補完) |
| B: nixpkgs-unstable への切り替え | 常に最新パッケージ | ビルド環境の再現性・安定性が下がる |
| C: 現状維持 | 作業不要 | 25.11 チャンネルは EOL に向かい、セキュリティ修正を受けられなくなる |

### 採用理由

安定チャンネル + SHA pin という既存の再現性方針を維持しつつ、サポート対象の最新安定版へ追従するため。pin の SHA はいずれも upstream の正規タグ (v7.0.1 / v31.11.0) の commit と一致することを GitHub API で照合済み。

## 変更箇所

- `flake.nix`: nixpkgs チャンネルを nixos-25.11 から nixos-26.05 へ変更
- `flake.lock`: nixpkgs を nixos-26.05 ブランチ HEAD (fd146203) へ更新
- `.github/workflows/build__site.yaml`: checkout v7.0.1・install-nix-action v31.11.0 へ pin 更新
- `.github/workflows/deploy__site.yaml`: 同上
- `.github/workflows/lint__directory_name.yaml`: checkout v7.0.1 へ pin 更新

## 妥協と制限

- **checkout pin のバージョン分岐**: managed workflow は v7.0.0 のまま残るため、リポジトリ内で v7.0.0 / v7.0.1 が併存する。解消は github_central 側の更新に委ねる

## 検証方法

- `nix run .#build` で nixos-26.05 環境 (bun 1.3.13 / go-task 3.48.0) のサイトビルド成功と `dist/index.html` 生成を確認
- pin した SHA が upstream タグの commit と一致することを GitHub API で照合
- prettier (差分なし)・yamllint (エラーなし)・actionlint (エラーなし) を通過
- flake.lock の rev が nixos-26.05 ブランチの実在 commit であることを確認

## 確認事項

- ⚠️ nixpkgs のメジャーチャンネル更新 (25.11 → 26.05) により bun が 1.3.13 へ上がる。ローカルビルドは成功済みだが、CI (build-test) の結果も併せて確認いただきたい

## 参考文献

- [actions/checkout v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1)
- [cachix/install-nix-action v31.11.0](https://github.com/cachix/install-nix-action/releases/tag/v31.11.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)